### PR TITLE
Fix build failure in macOS

### DIFF
--- a/build.c
+++ b/build.c
@@ -10,6 +10,7 @@
     #define ACCESS _access
     #define F_OK 0
 #else // unix & macos
+    #include <unistd.h>
     #include <sys/stat.h>
     #include <sys/types.h>
     #define STAT stat


### PR DESCRIPTION
build fails in macos.
this may also happen in other unix, but i didn't test.
the reason is that `build.c` lacks `unistd.h`.

```
$ cc build.c -o build 
build.c:86:9: error: call to undeclared function 'access'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
    if (ACCESS(binary, F_OK) != 0) return 1;  // binary does not exist, build it
        ^
build.c:16:20: note: expanded from macro 'ACCESS'
    #define ACCESS access
                   ^
build.c:86:24: error: use of undeclared identifier 'F_OK'
    if (ACCESS(binary, F_OK) != 0) return 1;  // binary does not exist, build it
                       ^
build.c:87:24: error: use of undeclared identifier 'F_OK'
    if (ACCESS(source, F_OK) != 0) return -1; // error: source does not exist, cannot build
                       ^
build.c:94:25: warning: format specifies type 'int' but the argument has type 'time_t' (aka 'long') [-Wformat]
    LOG_ERR("diff: %d", smod_time - bmod_time);
                   ~~   ^~~~~~~~~~~~~~~~~~~~~
                   %ld
build.c:28:81: note: expanded from macro 'LOG_ERR'
#define LOG_ERR(fmt, ...) printf(COLOR_BOLD_RED "ERR: " COLOR_RESET fmt "\n", ##__VA_ARGS__)
                                                                    ~~~         ^~~~~~~~~~~
1 warning and 3 errors generated.
```